### PR TITLE
Example configs for 18.01 minikube and container building script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docker-galaxy-stable"]
+	path = docker-galaxy-stable
+	url = https://github.com/bgruening/docker-galaxy-stable

--- a/README-galaxy-stable.md
+++ b/README-galaxy-stable.md
@@ -1,7 +1,18 @@
+# TL;DR
+
+To run a vanilla docker-galaxy-stable setup on Kubernetes using this chart on minikube:
+
+```
+helm install -f example_configs/galaxy-stable-18.01-minikube.yaml galaxy-helm-repo/galaxy-stable
+```
+
+This assumes that you at least followed the [Helm for the first time](README.md#galaxy-helm-charts) part and that you have checked out this repo (where the config file is available). Please note that this setup won't send jobs to the Kubernetes cluster, as it is not configured like that on the stock docker-galaxy-stable compose galaxy images. This feature requires changes in the `config/job_conf.xml`, which would mean that you need your own `galaxy-init` container flavour (like the [one built for PhenoMeNal](https://github.com/phnmnl/container-galaxy-k8s-runtime/blob/develop/Dockerfile_init) for instance).
+
+
+
 # Using docker-galaxy-stable compose images
 
-Using the docker-stable compose images with Kubernetes on this setup requires building those images with certain options being passed to the images, as done [here](https://github.com/phnmnl/container-galaxy-k8s-runtime/blob/develop/simplified_galaxy_stable_container_creation.sh). Please note that you will want to have your own version of `Docker_init` (like the one [here](https://github.com/phnmnl/container-galaxy-k8s-runtime/blob/develop/Dockerfile_init)). where you can setup your flavouring, tools and other settings to personalize the Galaxy instance that you will be deploying.
-
+Using the docker-stable compose images with Kubernetes on this setup requires building those images with certain options being passed to the images, as done [here](https://github.com/phnmnl/container-galaxy-k8s-runtime/blob/develop/simplified_galaxy_stable_container_creation.sh). Please note that you will want to have your own version of `Docker_init` (like the one [here](https://github.com/phnmnl/container-galaxy-k8s-runtime/blob/develop/Dockerfile_init)), where you can setup your flavouring, tools and other settings to personalize the Galaxy instance that you will be deploying.
 
 ## Variables
 

--- a/README-galaxy-stable.md
+++ b/README-galaxy-stable.md
@@ -1,6 +1,6 @@
 # TL;DR
 
-To run a vanilla docker-galaxy-stable setup on Kubernetes using this chart on minikube:
+To run a vanilla docker-galaxy-stable setup on Kubernetes using this chart on **minikube**:
 
 ```
 helm install -f example_configs/galaxy-stable-18.01-minikube.yaml galaxy-helm-repo/galaxy-stable

--- a/build-community-images-for-k8s.sh
+++ b/build-community-images-for-k8s.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -e
+
+DOCKER_REPO=${CONTAINER_REGISTRY:-}
+DOCKER_USER=${CONTAINER_USER:-pcm32}
+
+# Uncomment to push intermediate images, otherwise only the images needed for the helm chart are pushed.
+#PUSH_INTERMEDIATE_IMAGES=yes
+
+if [[ ${#DOCKER_REPO} > 0 ]];
+then
+    if [[ ! "$DOCKER_REPO" == */ ]];
+    then
+        DOCKER_REPO=$DOCKER_REPO"/"
+    fi
+fi
+
+
+ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
+ANSIBLE_RELEASE=18.01-k8s
+GALAXY_VER_FOR_POSTGRES=18.01
+POSTGRES_VERSION=`grep FROM docker-galaxy-stable/compose/galaxy-postgres/Dockerfile | awk -F":" '{ print $2 }'`
+GALAXY_BASE_FROM_TO_REPLACE=quay.io/bgruening/galaxy-base:18.01
+
+TAG=v18.01
+# Uncomment to avoid using the cache when building docker images.
+#NO_CACHE="--no-cache"
+
+if [[ ! -z ${CONTAINER_TAG_PREFIX+x} ]];
+then
+	if [[ ! -z ${BUILD_NUMBER+x} ]];
+	then
+            TAG=${CONTAINER_TAG_PREFIX}.${BUILD_NUMBER}
+        fi
+fi
+
+
+GALAXY_BASE_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-base:$TAG
+
+if [ -n $ANSIBLE_REPO ]
+    then
+       echo "Making custom galaxy-base:$TAG from $ANSIBLE_REPO at $ANSIBLE_RELEASE"
+       docker build $NO_CACHE --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t $GALAXY_BASE_TAG docker-galaxy-stable/compose/galaxy-base/
+       if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES+x} ]];
+       then
+	   echo "Pushing intermediate image $DOCKER_REPO$DOCKER_USER/galaxy-base:$TAG"
+           docker push $GALAXY_BASE_TAG
+       fi
+fi
+
+GALAXY_RELEASE=release_18.01
+GALAXY_REPO=galaxyproject/galaxy
+
+GALAXY_INIT_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init:$TAG
+
+if [ -n $GALAXY_REPO ]
+    then
+       echo "Making custom galaxy-init:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
+       DOCKERFILE_INIT_1=Dockerfile
+       if [ -n $ANSIBLE_REPO ]
+          then
+         sed s+$GALAXY_BASE_FROM_TO_REPLACE+$GALAXY_BASE_TAG+ docker-galaxy-stable/compose/galaxy-init/Dockerfile > docker-galaxy-stable/compose/galaxy-init/Dockerfile_init
+	       FROM=`grep ^FROM docker-galaxy-stable/compose/galaxy-init/Dockerfile_init | awk '{ print $2 }'`
+	       echo "Using FROM $FROM for galaxy init"
+	       DOCKERFILE_INIT_1=Dockerfile_init
+       fi
+       docker build $NO_CACHE --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE -t $GALAXY_INIT_TAG -f docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 docker-galaxy-stable/compose/galaxy-init/
+       #if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES+x} ]];
+       #then
+	       echo "Pushing intermediate image $GALAXY_INIT_TAG"
+         docker push $GALAXY_INIT_TAG
+       #fi
+fi
+
+# GALAXY_INIT_FLAVOURED_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init-flavoured:$TAG
+#
+# DOCKERFILE_INIT_FLAVOUR=Dockerfile_init
+# if [ -n $GALAXY_REPO ]
+# then
+# 	echo "Making custom galaxy-init-pheno-flavoured:$TAG starting from galaxy-init-pheno:$TAG"
+# 	sed s+pcm32/galaxy-init$+$GALAXY_INIT_PHENO_TAG+ Dockerfile_init > Dockerfile_init_tagged
+# 	DOCKERFILE_INIT_FLAVOUR=Dockerfile_init_tagged
+# fi
+# docker build $NO_CACHE -t $GALAXY_INIT_FLAVOURED_TAG -f $DOCKERFILE_INIT_FLAVOUR .
+# docker push $GALAXY_INIT_PHENO_FLAVOURED_TAG
+
+GALAXY_WEB_K8S_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG
+
+DOCKERFILE_WEB=Dockerfile
+if [ -n $GALAXY_REPO ]
+then
+	echo "Making custom galaxy-web-k8s:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
+	sed s+$GALAXY_BASE_FROM_TO_REPLACE+$GALAXY_BASE_TAG+ docker-galaxy-stable/compose/galaxy-web/Dockerfile > docker-galaxy-stable/compose/galaxy-web/Dockerfile_web
+	DOCKERFILE_WEB=Dockerfile_web
+fi
+docker build $NO_CACHE --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8,k8s -t $GALAXY_WEB_K8S_TAG -f docker-galaxy-stable/compose/galaxy-web/$DOCKERFILE_WEB docker-galaxy-stable/compose/galaxy-web/
+docker push $GALAXY_WEB_K8S_TAG
+
+# Build postgres
+POSTGRES_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-postgres:$POSTGRES_VERSION"_for_"$GALAXY_VER_FOR_POSTGRES
+docker build -t $POSTGRES_TAG -f docker-galaxy-stable/compose/galaxy-postgres/Dockerfile docker-galaxy-stable/compose/galaxy-postgres/
+docker push $POSTGRES_TAG
+
+# Build proftpd
+PROFTPD_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-proftpd:for_galaxy_v$GALAXY_VER_FOR_POSTGRES
+docker build -t $PROFTPD_TAG -f docker-galaxy-stable/compose/galaxy-proftpd/Dockerfile docker-galaxy-stable/compose/galaxy-proftpd/
+docker push $PROFTPD_TAG
+
+
+echo "Relevant containers:"
+echo "Web:          $GALAXY_WEB_K8S_TAG"
+echo "Init:         $GALAXY_INIT_TAG"
+echo "Postgres:     $POSTGRES_TAG"
+echo "Proftpd:      $PROFTPD_TAG"

--- a/example_configs/galaxy-stable-18.01-minikube.yaml
+++ b/example_configs/galaxy-stable-18.01-minikube.yaml
@@ -1,0 +1,97 @@
+# Relevant containers:
+# Web:          pcm32/galaxy-web-k8s:v18.01
+# Init:         pcm32/galaxy-init:v18.01
+# Postgres:     pcm32/galaxy-postgres:9.6.5_for_18.01
+# Proftpd:      pcm32/galaxy-proftpd:for_galaxy_v18.01
+
+# Default values for galaxy-stable.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+galaxy:
+  init:
+    image:
+      repository: pcm32/galaxy-init
+      tag: v18.01
+      pullPolicy: Always
+    resources: {}
+  backend:
+    postgres: true
+  image:
+    repository: pcm32/galaxy-web-k8s
+    tag: v18.01
+    pullPolicy: Always
+# Probably not needed as all on /export
+  tools:
+    destination: "/export/tools"
+  # destinations_default: "k8s" # currently this doesn't work with community images
+  k8s:
+    supp_groups: 0
+    fs_group: 0
+  admin:
+    email: "admin@email.do"
+    password: "admin-pass"
+    api_key: "qwertyqweqwe"
+    username: admin
+  #smtp:
+  #  server: "email.server.do"
+  #  username: "email-user"
+  #  password: "email-pass"
+  #  email_from: "user@server.do"
+  #  ssl: 'False'
+  instance_resource_url: "localhost"
+  internal_port: 80
+  node_port_exposed: 30700
+  create_pvc: true
+  pvc:
+    name: galaxy-pvc
+    capacity: "15Gi"
+    # subPath:
+# development_folder:
+service:
+  name: galaxy-svc
+  type: NodePort
+pv_minikube: true
+pv:
+  minikube:
+      hostPath: "/data/galaxy-stable-18.01"
+use_ingress: false
+external_ingress_controller: false
+ingress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - chart-example.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+use_condor: false
+postgres_for_galaxy:
+  db_password: "change-me"
+  postgres_pvc: "galaxy-pvc"
+  subpath: "postgres"
+  postgres_image: "pcm32/galaxy-postgres"
+  postgres_image_tag: ":9.6.5_for_18.01"
+proftpd:
+  generate_ssh_key: true
+  image:
+    repository: "pcm32/galaxy-proftpd"
+    tag: "for_galaxy_v18.01"
+legacy:
+  pre_k8s_16: false

--- a/example_configs/galaxy-stable-phenomenal-18.01-minikube.yaml
+++ b/example_configs/galaxy-stable-phenomenal-18.01-minikube.yaml
@@ -1,0 +1,96 @@
+# Web:          pcm32/galaxy-web-k8s:v18.01-pheno-dev
+# Init Flavour: pcm32/galaxy-init-pheno-flavoured:v18.01-pheno-dev
+# Postgres:     pcm32/galaxy-postgres:9.6.5_for_18.01
+# Proftpd:      pcm32/galaxy-proftpd:for_galaxy_v18.01
+#
+# Default values for galaxy-stable.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+galaxy:
+  init:
+    image:
+      repository: pcm32/galaxy-init-pheno-flavoured
+      tag: v18.01-pheno-dev
+      pullPolicy: Always
+    resources: {}
+  backend:
+    postgres: true
+  image:
+    repository: pcm32/galaxy-web-k8s
+    tag: v18.01-pheno-dev
+    pullPolicy: Always 
+# Probably not needed as all on /export
+  tools:
+    destination: "/export/tools"
+  destinations_default: "k8s"
+  k8s:
+    supp_groups: 0
+    fs_group: 0
+  admin:
+    email: "admin@email.do"
+    password: "admin-pass"
+    api_key: "qwertyqweqwe"
+    username: admin
+  #smtp:
+  #  server: "email.server.do"
+  #  username: "email-user"
+  #  password: "email-pass"
+  #  email_from: "user@server.do"
+  #  ssl: 'False'
+  instance_resource_url: "localhost" 
+  internal_port: 80
+  node_port_exposed: 30700
+  create_pvc: true
+  pvc:
+    name: galaxy-pvc
+    capacity: "15Gi"
+    # subPath:
+# development_folder:
+service:
+  name: galaxy-svc
+  type: NodePort
+pv_minikube: true
+pv:
+  minikube:
+      hostPath: "/data/galaxy-stable-data-18.01"
+use_ingress: false
+external_ingress_controller: false 
+ingress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - chart-example.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious 
+  # choice for the user. This also increases chances charts run on environments with little 
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following 
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+use_condor: false
+postgres_for_galaxy:
+  db_password: "change-me"
+  postgres_pvc: "galaxy-pvc"
+  subpath: "postgres"
+  postgres_image: "pcm32/galaxy-postgres"
+  postgres_image_tag: ":9.6.5_for_18.01"
+proftpd:
+  generate_ssh_key: true
+  image:
+    repository: "pcm32/galaxy-proftpd"
+    tag: "for_galaxy_v18.01"
+legacy:
+  pre_k8s_16: false


### PR DESCRIPTION
- Example configs tested for lifting a vanilla Galaxy setup (18.01) with helm. 
- Container building script to produce community images containers with the correct settings, configurable to look into different galaxy repos and ansible-galaxy-extras.

Will add documentation on how to use this on the readme.