### PR TITLE
log to k8s

### DIFF
--- a/galaxy/templates/galaxy_rc.yaml
+++ b/galaxy/templates/galaxy_rc.yaml
@@ -141,8 +141,9 @@ spec:
             - name: "GALAXY_CONFIG_SMTP_SSL"
               value: "{{.Values.smtp_ssl}}"
 {{ end }}
-        command: ["/bin/bash","-c","{{ if not .Values.galaxy_backend_postgres }}mkdir -p /opt/galaxy_data/database-sqlite && {{ end }}./ansible/run_galaxy_config.sh > config_db.log && ./run.sh --daemon && tail -f {{.Values.log_file_to_track}}"]
-        lifecycle: 
+        command: ["/bin/bash","-c",
+          "./ansible/run_galaxy_config.sh && ./run.sh --daemon && tail -f {{.Values.log_file_to_track}}"]
+        lifecycle:
           preStop:
             exec:
                command:

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -79,7 +79,7 @@ galaxy_backend_postgres: false
 
 legacy:
    pre_k8s_16: false
-rbac_needed: false
+rbac_needed: true
 
 k8s_supp_groups: ""
 

--- a/galaxy/values.yaml
+++ b/galaxy/values.yaml
@@ -79,7 +79,7 @@ galaxy_backend_postgres: false
 
 legacy:
    pre_k8s_16: false
-rbac_needed: true
+rbac_needed: false
 
 k8s_supp_groups: ""
 


### PR DESCRIPTION
This PR:

1. lets stderr and stdout from `run_galaxy_config.sh` be captured by kubernetes, rather than sending only stdout to the file `config_db.log` and letting stderr go to k8s;
2. it removes the conditional creation of the sqlite directory since run_galaxy_config.sh already does that;
3. it sets `rbac_needed` to true by default.