### PR TITLE
Pins alpine to 3.7

### DIFF
--- a/galaxy-stable/templates/deployment.yaml
+++ b/galaxy-stable/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           [
             {
               "name": "postgres-listener",
-              "image": "alpine:3.8",
+              "image": "alpine:3.7",
               "imagePullPolicy": "IfNotPresent",
               "command": [
                 "sh", "-c",
@@ -51,7 +51,7 @@ spec:
 {{ toYaml .Values.galaxy.init.resources | indent 12 }}
         {{ if and .Values.galaxy.backend.postgres (not .Values.legacy.pre_k8s_16) }}
         - name: postgres-listener
-          image: alpine:3.8
+          image: "alpine:3.7"
           imagePullPolicy: IfNotPresent
           command: [ "sh", "-c", "for i in $(seq 1 200); do nc -z -w3 postgresql-for-galaxy 5432 && exit 0 || sleep 3; done; exit 1"]
         {{ end }}

--- a/galaxy-stable/templates/deployment.yaml
+++ b/galaxy-stable/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           [
             {
               "name": "postgres-listener",
-              "image": "alpine",
+              "image": "alpine:3.8",
               "imagePullPolicy": "IfNotPresent",
               "command": [
                 "sh", "-c",
@@ -51,7 +51,7 @@ spec:
 {{ toYaml .Values.galaxy.init.resources | indent 12 }}
         {{ if and .Values.galaxy.backend.postgres (not .Values.legacy.pre_k8s_16) }}
         - name: postgres-listener
-          image: alpine
+          image: alpine:3.8
           imagePullPolicy: IfNotPresent
           command: [ "sh", "-c", "for i in $(seq 1 200); do nc -z -w3 postgresql-for-galaxy 5432 && exit 0 || sleep 3; done; exit 1"]
         {{ end }}


### PR DESCRIPTION
Avoids using `:latest` tag for alpine, pins it to 3.8 (issues with latest transiently on dockerhub).