### PR TITLE
Adds UWSGI env variable support and sets default to / instead of /galaxy

### DIFF
--- a/galaxy-stable/Chart.yaml
+++ b/galaxy-stable/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Galaxy is an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 name: galaxy-stable
-version: 2.0.0
+version: 2.0.1

--- a/galaxy-stable/templates/galaxy_container_cfgmap.yaml
+++ b/galaxy-stable/templates/galaxy_container_cfgmap.yaml
@@ -38,6 +38,12 @@ data:
   "PROXY_PREFIX": "{{ .Values.ingress.path }}"
   {{- end }}
 
+  {{- range $key, $val := .Values.uwsgi}}
+  {{- if $val }}
+  UWSGI_{{ $key | upper }}: {{ quote $val }}
+  {{- end }}
+  {{- end }}
+
   {{- range $key, $val := .Values.job_conf.runners }}
   {{- if $val }}
   GALAXY_RUNNERS_{{ $key | upper }}: {{ quote $val }}

--- a/galaxy-stable/values.yaml
+++ b/galaxy-stable/values.yaml
@@ -45,6 +45,9 @@ galaxy_conf:
   admin_users: "admin@galaxyproject.org"
   allow_user_deletion:
   allow_user_creation:
+  # Sets prefix to / as default. Check container setup, uwsgi.mount and
+  # ingress.path values when changing this. 
+  filter-with: /
   # smtp_server:
   # smtp_username:
   # smtp_password:
@@ -53,6 +56,20 @@ galaxy_conf:
   # url:
   # ftp_upload_site:
   containers_resolvers_config_file: "/export/config/container_resolvers_conf.xml"
+
+# settings that affect uwsgi, variable my_var within uwsgi will be transformed
+# to UWSGI_MY_VAR inside the container.
+uwsgi:
+  # We are setting / as the default instead of /galaxy since the default of the
+  # docker-galaxy-stable compose containers is to configure NGINX to be using
+  # / instead of /galaxy. This unfortunately happens at build time of the
+  # container and is not easy to change through environment variables once
+  # the galaxy-web container has been built. In other words, in order to used
+  # a different prefix, this currently needs to be configured as well on
+  # container build time.
+  # Also, if making changes here, make sure that ingress.path and
+  # galaxy_conf.filter-with variables are set accordingly.
+  mount: "/=galaxy.webapps.galaxy.buildapp:uwsgi_app()"
 
 # settings which affect job_conf.xml
 job_conf:
@@ -116,7 +133,14 @@ ingress:
   # enable to add a custom nginx replication controller for nginx.
   # Leave diabled and enable nginx annotation to use kube provider managed ingress controller.
   self_managed: false
-  path: /galaxy
+  # For using a URL prefix, like /galaxy, change path: from / to /galaxy
+  # Please note that you need to be using a container where nginx is adequately
+  # configured to use such a prefix (in docker-galaxy-stable this currently
+  # happens on build time unfortunately, and / is the default).
+  # Also make sure that value uwsgi.mount is coherent with this setting,
+  # otherwise UWSGI and NGINX will operate differently and you will get all sort
+  # of HTTP errors, problems upload, etc.
+  path: /
   # Used to create Ingress record (should used with service.type: ClusterIP).
   annotations:
     kubernetes.io/ingress.class: nginx
@@ -129,9 +153,9 @@ ingress:
     #   hosts:
     #     - chart-example.local
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious 
-  # choice for the user. This also increases chances charts run on environments with little 
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following 
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #  cpu: 100m
@@ -166,7 +190,7 @@ condor:
 proftpd:
   enabled: true
   replicaCount: 1
-  image: 
+  image:
     repository: "container-registry.phenomenal-h2020.eu/phnmnl/galaxy-proftpd"
     tag: "for_galaxy_v17.09"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
This PR:

- Adds the ability to set UWSGI_ environment variables for the configuration of UWSGI.
- Sets default case to serve galaxy at `/` instead of `/galaxy`. This default is chosen as the docker-galaxy-stable compose images seem to be configuring NGINX by default for this setup (and this is unfortunately done at container build time). Using `/galaxy`on UWSGI when NGINX is not set for this produces all set of weird HTML behaviour like #29 or broken http pulled file uploads, among others.