### PR TITLE
[WIP] Improve 18.01 example to allow tools installation

### DIFF
--- a/example_configs/galaxy-stable-18.01-minikube.yaml
+++ b/example_configs/galaxy-stable-18.01-minikube.yaml
@@ -41,6 +41,9 @@ admin:
 galaxy_conf:
   brand: "k8s"
   url: "localhost"
+  admin_users= "admin@email.do"
+  conda_auto_install: false
+  enable_beta_mulled_containers: true
 
 # development_folder:
 service:


### PR DESCRIPTION
With this changes the flavour less image should resolve conda packages for tools installed from the toolshed, making the flavour-less setup more interesting for people trying it.