### PR TITLE
NONUSE slurm

### DIFF
--- a/galaxy-stable/templates/galaxy_container_cfgmap.yaml
+++ b/galaxy-stable/templates/galaxy_container_cfgmap.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  "NONUSE": "sleeplock{{ if not .Values.condor.enabled }},condor{{ end }}"
+  "NONUSE": "sleeplock{{ if not .Values.condor.enabled }},condor{{ end }}{{ if not .Values.slurm.enabled }},slurmctld,slurmd{{ end }}"
   "GALAXY_TOOLS_PULL_POLICY": {{ .Values.image.pullPolicy }}
   {{- if .Values.postgresql.enabled }}
   "GALAXY_SEC_DB_ENGINE": "postgresql"

--- a/galaxy-stable/values.yaml
+++ b/galaxy-stable/values.yaml
@@ -187,6 +187,9 @@ rbac:
 condor:
   enabled: false
 
+slurm:
+  enabled: false
+
 proftpd:
   enabled: true
   replicaCount: 1


### PR DESCRIPTION
Add ability to set NONUSE on slurm, so that newer 18.09 versions don't need to wait for lengthy slurm startup (2 minutes I think currently). This is not finished or tested yet.