### PR TITLE
Fix rbac to allow multiple deployments

### DIFF
--- a/galaxy-stable/Chart.yaml
+++ b/galaxy-stable/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Galaxy is an open, web-based platform for accessible, reproducible, and transparent computational biomedical research.
 name: galaxy-stable
-version: 2.0.1
+version: 2.0.2

--- a/galaxy-stable/templates/galaxy_rbac.yaml
+++ b/galaxy-stable/templates/galaxy_rbac.yaml
@@ -3,7 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: galaxy-role-pods-jobs
+  name: {{ template "galaxy.fullname" . }}-role-pods-jobs
   labels:
     app: {{ template "galaxy.name" . }}
     chart: {{ template "galaxy.chart" . }}
@@ -20,13 +20,13 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: galaxy-operations
+  name: {{ template "galaxy.fullname" . }}-operations
 subjects:
 - kind: ServiceAccount
   name: default
   namespace: default
 roleRef:
   kind: Role
-  name: galaxy-role-pods-jobs
+  name: {{ template "galaxy.fullname" . }}-role-pods-jobs
   apiGroup: rbac.authorization.k8s.io
 {{ end }}


### PR DESCRIPTION
Currently RBAC API objects where using the same name regardless of the helm deployment name, this PR fixes that so that. I have used this locally to work fine.